### PR TITLE
Use Event.target instead of nonstandard Event.originalTarget

### DIFF
--- a/index.html
+++ b/index.html
@@ -600,7 +600,7 @@ function update_transfers(candidates, event) {
     }
 
     transfers.textContent = "";
-    let votes = event.originalTarget.votes;
+    let votes = event.target.votes;
     if (!votes) {
         return;
     }


### PR DESCRIPTION
[`Event.originalTarget`](https://developer.mozilla.org/en-US/docs/Web/API/Event/originalTarget) is a Mozilla-only property apparently used in XBL to access [anonymous elements](https://developer.mozilla.org/en-US/docs/Mozilla/Tech/XBL/XBL_1.0_Reference/Anonymous_Content#Event_Flow_and_Targeting). (Maybe it is confused with [`Event.currentTarget`](https://developer.mozilla.org/en-US/docs/Web/API/Event/currentTarget) which *is* a standard DOM Level 2 property.) Use `Event.target` instead.